### PR TITLE
feat: add Dockerfile for microservice deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json .
+COPY package-lock.json .
+
+RUN npm install
+
+COPY bin/ ./bin
+COPY models/ ./models
+COPY public/ ./public
+COPY routes/ ./routes
+COPY services/ ./services
+COPY app.js .
+COPY .env .
+
+EXPOSE 3000
+
+CMD npm start


### PR DESCRIPTION
This pull request introduces a Dockerfile for the MS-Catalogue microservice, enabling containerization and simplifying deployment processes. The Dockerfile defines all necessary steps to build and run the application in a Docker container, including setting up dependencies, exposing the correct port, and specifying the entry point for the microservice.
